### PR TITLE
Fix for MacOSX .pkg creation during build

### DIFF
--- a/cmake/PluginPackage.cmake
+++ b/cmake/PluginPackage.cmake
@@ -159,6 +159,9 @@ MESSAGE (STATUS "*** Staging to build PlugIn OSX Package ***")
 
 configure_file(${PROJECT_SOURCE_DIR}/cmake/gpl.txt
             ${CMAKE_CURRENT_BINARY_DIR}/license.txt COPYONLY)
+	    
+configure_file(${PROJECT_SOURCE_DIR}/buildosx/InstallOSX/pkg_background.jpg
+            ${CMAKE_CURRENT_BINARY_DIR}/pkg_background.jpg COPYONLY)
 
  # Patch the pkgproj.in file to make the output package name conform to Xxx-Plugin_x.x.pkg format
  #  Key is:


### PR DESCRIPTION
Ok. Found the issue. It took me a couple of tries, but this correct to the PluginPackage.cmake file includes the missing .jpg, eliminating the need to manually copy over the file as a work-around.