### PR TITLE
Replace missing refdata initialization code in wxJSONValue::Init()

### DIFF
--- a/src/wxJSON/jsonval.cpp
+++ b/src/wxJSON/jsonval.cpp
@@ -209,6 +209,12 @@ wxJSONValue::Init( wxJSONType type )
 {
     wxJSONRefData* data;
     data = GetRefData();
+    if (data != 0) {
+        UnRef();
+    }
+
+    // we allocate a new instance of the referenced data
+    data = new wxJSONRefData();
     wxJSON_ASSERT( data );
 
     // in release builds we do not have ASSERT so we check 'data' before


### PR DESCRIPTION
When testing with OpenCPN and WMM plugin dashboard_t causes a crash by dereferencing a null pointer.  So I copied some missing code from the old dashboard plugin wxJSONValue::Init() function. Now it doesn't crash O when WMM is active.

Someone should check why the Init() function was changed and verify if this is a good solution or not.