### PR TITLE
Open preferences dialog in viewport center.

### DIFF
--- a/src/dashboard_pi.cpp
+++ b/src/dashboard_pi.cpp
@@ -2495,17 +2495,12 @@ int dashboard_pi::GetToolbarToolCount( void )
 
 void dashboard_pi::ShowPreferencesDialog( wxWindow* parent )
 {
-#ifdef _TACTICSPI_H_
-    wxPoint pos = wxGetMousePosition();
-    pos.y -= 500;
-    pos.x -= 100;
-#endif // _TACTICSPI_H_
     DashboardPreferencesDialog *dialog = new DashboardPreferencesDialog( parent, wxID_ANY,
                                                                          m_ArrayOfDashboardWindow
 #ifdef _TACTICSPI_H_
                                                                          , GetCommonName(),
                                                                          GetNameVersion(),
-                                                                         pos
+                                                                         wxDefaultPosition
 #endif // _TACTICSPI_H_
      );
 
@@ -3456,6 +3451,8 @@ DashboardPreferencesDialog::DashboardPreferencesDialog(
     UpdateButtonsState();
     SetMinSize( wxSize( 450, -1 ) );
     Fit();
+    if ( pos == wxDefaultPosition )
+        Center();
 }
 
 void DashboardPreferencesDialog::OnCloseDialog( wxCloseEvent& event )

--- a/src/dashboard_pi.h
+++ b/src/dashboard_pi.h
@@ -323,7 +323,7 @@ class DashboardPreferencesDialog : public
 public:
     DashboardPreferencesDialog( wxWindow *pparent, wxWindowID id, wxArrayOfDashboard config
 #ifdef _TACTICSPI_H_
-                                , wxString commonName, wxString nameVersion, wxPoint pos 
+                                , wxString commonName, wxString nameVersion, wxPoint pos = wxDefaultPosition
 #endif // _TACTICSPI_H_
         );
     ~DashboardPreferencesDialog() {}


### PR DESCRIPTION
IMO it is annoying that the preferences dialog opens partially off screen in many cases.  This PR always opens it in the center of the main window.