### PR TITLE
Changes for compiling on RPI4 focal arm64 (wxWidgets + package)

### DIFF
--- a/cmake/PluginConfigure.cmake
+++ b/cmake/PluginConfigure.cmake
@@ -53,9 +53,14 @@ IF (NOT WIN32)
   ENDIF (UNIX AND NOT APPLE)
 endif(NOT WIN32)
 
-IF (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-  SET (ARCH "armhf")
+  IF (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+    IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
+      SET (ARCH "arm64")
+  ADD_DEFINITIONS( -DARM64 )
+    ELSE ()
+      SET (ARCH "armhf")
   ADD_DEFINITIONS( -DARMHF )
+    ENDIF ()
 ENDIF (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
 
 MESSAGE (STATUS "*** Build Architecture is ${ARCH}")
@@ -131,7 +136,7 @@ IF(MSVC)
 ENDIF(MSVC)
 
 IF(NOT DEFINED wxWidgets_USE_FILE)
-    SET(wxWidgets_FIND_COMPONENTS base core net xml html adv aui webview)
+  SET(wxWidgets_USE_LIBS base core net xml html adv aui)
 ENDIF(NOT DEFINED wxWidgets_USE_FILE)
 
 #  QT_ANDROID is a cross-build, so the native FIND_PACKAGE(wxWidgets...) and wxWidgets_USE_FILE is not useful.

--- a/cmake/PluginConfigure.cmake
+++ b/cmake/PluginConfigure.cmake
@@ -136,12 +136,11 @@ IF(MSVC)
 ENDIF(MSVC)
 
 IF(NOT DEFINED wxWidgets_USE_FILE)
-#  SET(wxWidgets_FIND_COMPONENTS base core net xml html adv aui webview)
-#  SET(wxWidgets_USE_LIBS base core net xml html adv aui)
-  SET(wxWidgets_USE_LIBS base core net xml html adv aui webview)
-# WIP: detection of wxWidget differs between platforms
-#      First settings => original, Win / Second ARM64 Bionic /Third ARM64 Focal
-#      Need a build test now first WIN + Focal (Breaks Bionic)
+  IF(UNIX)
+    SET(wxWidgets_USE_LIBS base core net xml html adv aui)
+  ELSE(UNIX)
+    SET(wxWidgets_FIND_COMPONENTS base core net xml html adv aui webview)
+  ENDIF(UNIX)
 ENDIF(NOT DEFINED wxWidgets_USE_FILE)
 
 #  QT_ANDROID is a cross-build, so the native FIND_PACKAGE(wxWidgets...) and wxWidgets_USE_FILE is not useful.

--- a/cmake/PluginConfigure.cmake
+++ b/cmake/PluginConfigure.cmake
@@ -136,7 +136,12 @@ IF(MSVC)
 ENDIF(MSVC)
 
 IF(NOT DEFINED wxWidgets_USE_FILE)
-  SET(wxWidgets_USE_LIBS base core net xml html adv aui)
+#  SET(wxWidgets_FIND_COMPONENTS base core net xml html adv aui webview)
+#  SET(wxWidgets_USE_LIBS base core net xml html adv aui)
+  SET(wxWidgets_USE_LIBS base core net xml html adv aui webview)
+# WIP: detection of wxWidget differs between platforms
+#      First settings => original, Win / Second ARM64 Bionic /Third ARM64 Focal
+#      Need a build test now first WIN + Focal (Breaks Bionic)
 ENDIF(NOT DEFINED wxWidgets_USE_FILE)
 
 #  QT_ANDROID is a cross-build, so the native FIND_PACKAGE(wxWidgets...) and wxWidgets_USE_FILE is not useful.

--- a/cmake/PluginPackage.cmake
+++ b/cmake/PluginPackage.cmake
@@ -78,7 +78,11 @@ IF(UNIX AND NOT APPLE)
 
 
   IF (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-    SET (ARCH "armhf")
+    IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
+      SET (ARCH "arm64")
+    ELSE ()
+      SET (ARCH "armhf")
+    ENDIF ()
     # don't bother with rpm on armhf
     SET(CPACK_GENERATOR "DEB;RPM;TBZ2")
   ELSE ()


### PR DESCRIPTION
	modified:   cmake/PluginConfigure.cmake
	modified:   cmake/PluginPackage.cmake

Fixes #

PluginConfigure.cmake fixes the detection of wxWidgets on Ubuntu Focal 20.04 (GTK3).
Here might be dragons (I copied the detection from oeSENC so it is tested).

PluginPackage.cmake makes it possible to build a package for ARM64. Also copy paste tested patch.

## Proposed Changes

More or less oneliners to make a difference between ARMHF and ARM64

