### PR TITLE
Docs: remove refs. beta.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,6 @@
-Fixes #
+## Fixes
+
+_What will be fixed_
 
 ## Proposed Changes
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,8 +6,8 @@ _Briefly describe your proposed changes:_
 
 ## Checklist (change to [X] when sure)
 
-  - [ ] You are committing a branch which starts with a 'pr', such as 'pr151', 'pr200'
+  - [ ] You are committing a branch which starts with a 'dev', such as 'dev220'
   - [ ] A test use case has been added or modified if appropriate
-  - [ ] Your pull request passes CI on Windows (AppVeyor), Linux and MacOS (Travis)
+  - [ ] Your pull request passes CI on Windows (AppVeyor), Linux, optionally MacOS (Travis)
   - [ ] Your pull request does not create static QA (Codacy) rejection
   - [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,8 @@ For this reason, it is adviced to use always the latest stable version or the la
 | ------- | ------------------ |
 | <=1.5.1 | :x:                |
 | 1.98.x  | :x:                |
-| 1.99.x  | :white_check_mark: |
+| 1.99.x  | :x:                |
+| 2.0.x   | :white_check_mark: |
 
 ## Currently open security reports
 

--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2020, Petri Mäkijärvi'
 author = 'Petri Mäkijärvi'
 
 # The full version, including alpha/beta/rc tags
-release = 'v2.0-beta02'
+release = 'v2.0.0'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Fixes

Document version not showing beta anymore.

## Proposed Changes

Readthedocs and Github config files.

## Checklist (change to [X] when sure)

  - [X] You are committing a branch which starts with a 'dev', such as 'dev220'
  - [X] A test use case has been added or modified if appropriate
  - [X] Your pull request passes CI on Windows (AppVeyor), Linux, optionally MacOS (Travis)
  - [X] Your pull request does not create static QA (Codacy) rejection
  - [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
